### PR TITLE
Remove limit field from findAndModify commands

### DIFF
--- a/lib/mongo_queue.rb
+++ b/lib/mongo_queue.rb
@@ -83,7 +83,6 @@ class Mongo::Queue
     }
     cmd['query']         = query
     cmd['sort']          = sort_hash
-    cmd['limit']         = 1
     cmd['new']           = true
     run(cmd)
   end
@@ -109,7 +108,6 @@ class Mongo::Queue
                 {:active_at => {'$lt' => Time.now.utc}}]
     }
     cmd['sort']          = sort_hash
-    cmd['limit']         = 1
     cmd['new']           = true
     run(cmd)
   end
@@ -140,7 +138,6 @@ class Mongo::Queue
                             }}
     cmd['query']         = {:locked_by => locked_by,
       :_id => BSON::ObjectId.from_string(doc['_id'].to_s)}
-    cmd['limit']         = 1
     cmd['new']           = true
     run(cmd)
   end
@@ -153,7 +150,6 @@ class Mongo::Queue
     cmd['query']         = {:locked_by => locked_by, 
       :_id => BSON::ObjectId.from_string(doc['_id'].to_s)}
     cmd['remove']        = true
-    cmd['limit']         = 1
     run(cmd)
   end
 


### PR DESCRIPTION
The [`findAndModify`](https://docs.mongodb.com/manual/reference/command/findAndModify/) command doesn't accept `limit` as it is not a valid field. This can result in failures such as:

> MONGODB | [77] localhost:27017 | soter_fork_test_dev.findandmodify | FAILED | BSON field 'limit' is an unknown field. (51177) | 0.028634s

This has not been tested thoroughly and is just based on an observation at this point